### PR TITLE
Build for android + consistently use yarn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,30 +16,30 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Bundle
+      - name: Install bundle
         run: |
-          set -o pipefail
+          set -euxo pipefail
           bundle install
 
       - name: Install node modules
         run: |
-          set -o pipefail
+          set -euxo pipefail
           yarn install --immutable
 
       - name: Install pods
         working-directory: ios
         run: |
-          set -o pipefail
+          set -euxo pipefail
           bundle exec pod install
 
       - name: Build iOS
         working-directory: ios
         run: |
-          set -o pipefail
-          npx react-native build-ios
+          set -euxo pipefail
+          yarn build-ios
 
       - name: Build Android
         working-directory: ios
         run: |
-          set -o pipefail
-          npx react-native build-android
+          set -euxo pipefail
+          yarn build-android

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "build-android": "react-native build-android",
     "android": "react-native run-android",
+    "build-ios": "react-native build-ios",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",


### PR DESCRIPTION
This PR adds building for android to the CI workflow. It also adds consistent usage of yarn.