### PR TITLE
Use checkout@v4 action instead of v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - vr/update-checkout
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Use checkout@v4 since it uses node v20 instead of v16 which is already EOL.